### PR TITLE
Implement Concept Set Generator

### DIFF
--- a/athena_client/concept_set.py
+++ b/athena_client/concept_set.py
@@ -1,0 +1,105 @@
+import logging
+from typing import Any, Dict, List
+
+from .concept_explorer import ConceptExplorer
+from .db.base import DatabaseConnector
+
+logger = logging.getLogger(__name__)
+
+
+class ConceptSetGenerator:
+    """Orchestrate concept set generation from a search query."""
+
+    def __init__(self, explorer: ConceptExplorer, db: DatabaseConnector) -> None:
+        self.explorer = explorer
+        self.db = db
+
+    async def create_from_query(
+        self,
+        query: str,
+        strategy: str = "fallback",
+        include_descendants: bool = True,
+        confidence_threshold: float = 0.7,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate a concept set using a tiered standard-first strategy."""
+        logger.info(
+            "Attempting to find and validate standard concepts for query: '%s'",
+            query,
+        )
+        mappings = await self.explorer.map_to_standard_concepts(
+            query, confidence_threshold=confidence_threshold, **kwargs
+        )
+
+        from .models import ConceptType
+
+        standard_concepts = [
+            m["concept"]
+            for m in mappings
+            if m["concept"].standardConcept == ConceptType.STANDARD
+        ]
+
+        if standard_concepts:
+            candidate_ids = [c.id for c in standard_concepts]
+            validated_ids = self.db.validate_concepts(candidate_ids)
+
+            if validated_ids:
+                final_ids = set(validated_ids)
+                if include_descendants:
+                    desc_ids = self.db.get_descendants(validated_ids)
+                    final_ids.update(desc_ids)
+
+                return self._build_success_response(
+                    query=query,
+                    strategy_used="Tier 1: Direct Standard Concept",
+                    concept_ids=list(final_ids),
+                    seed_concepts=validated_ids,
+                )
+
+        if strategy == "strict":
+            return self._build_failure_response(
+                query, "No standard concepts could be validated in 'strict' mode."
+            )
+
+        return self._build_failure_response(
+            query,
+            (
+                "No standard concepts from the API could be validated against "
+                "the local database."
+            ),
+        )
+
+    def _build_success_response(
+        self,
+        query: str,
+        strategy_used: str,
+        concept_ids: List[int],
+        seed_concepts: List[int],
+    ) -> Dict[str, Any]:
+        return {
+            "name": f"Concept Set for '{query}'",
+            "concept_ids": concept_ids,
+            "metadata": {
+                "status": "SUCCESS",
+                "strategy_used": strategy_used,
+                "source_query": query,
+                "seed_concepts": seed_concepts,
+                "warnings": [],
+            },
+        }
+
+    def _build_failure_response(self, query: str, reason: str) -> Dict[str, Any]:
+        return {
+            "name": f"Failed Concept Set for '{query}'",
+            "concept_ids": [],
+            "metadata": {
+                "status": "FAILURE",
+                "source_query": query,
+                "reason": reason,
+                "suggestions": [
+                    "Try a different search term.",
+                    "Lower the `confidence_threshold`.",
+                    "Check if your local vocabulary version is up to date.",
+                ],
+            },
+        }

--- a/athena_client/db/base.py
+++ b/athena_client/db/base.py
@@ -7,3 +7,7 @@ class DatabaseConnector(Protocol):
     def validate_concepts(self, concept_ids: List[int]) -> List[int]:
         """Validate concept IDs against the local database."""
         ...
+
+    def get_descendants(self, concept_ids: List[int]) -> List[int]:
+        """Return descendant concept IDs for the given ancestors."""
+        ...

--- a/tests/db/test_sqlalchemy_connector.py
+++ b/tests/db/test_sqlalchemy_connector.py
@@ -57,3 +57,46 @@ class TestSQLAlchemyConnector:
             connector = SQLAlchemyConnector.from_connection_string("sqlite:///:memory:")
             assert connector._engine is engine
             mock_create.assert_called_once_with("sqlite:///:memory:")
+
+    def test_get_descendants_success(self):
+        engine = Mock()
+        connection = Mock()
+        engine.connect.return_value.__enter__ = Mock(return_value=connection)
+        engine.connect.return_value.__exit__ = Mock(return_value=None)
+        connection.execute.return_value = [(1,), (2,), (3,)]
+
+        connector = SQLAlchemyConnector(engine)
+        result = connector.get_descendants([1])
+
+        assert set(result) == {2, 3}
+
+    def test_get_descendants_no_descendants(self):
+        engine = Mock()
+        connection = Mock()
+        engine.connect.return_value.__enter__ = Mock(return_value=connection)
+        engine.connect.return_value.__exit__ = Mock(return_value=None)
+        connection.execute.return_value = [(1,)]
+
+        connector = SQLAlchemyConnector(engine)
+        result = connector.get_descendants([1])
+
+        assert result == []
+
+    def test_get_descendants_empty_input(self):
+        engine = Mock()
+        connector = SQLAlchemyConnector(engine)
+
+        assert connector.get_descendants([]) == []
+        engine.connect.assert_not_called()
+
+    def test_get_descendants_invalid_id(self):
+        engine = Mock()
+        connection = Mock()
+        engine.connect.return_value.__enter__ = Mock(return_value=connection)
+        engine.connect.return_value.__exit__ = Mock(return_value=None)
+        connection.execute.return_value = []
+
+        connector = SQLAlchemyConnector(engine)
+        result = connector.get_descendants([999])
+
+        assert result == []

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -429,3 +429,10 @@ class TestAthenaAsyncClient:
                 import importlib
 
                 importlib.import_module("athena_client.async_client")
+
+    @pytest.mark.asyncio
+    async def test_generate_concept_set_without_db(self):
+        client = AthenaAsyncClient()
+
+        with pytest.raises(RuntimeError):
+            await client.generate_concept_set("test")

--- a/tests/test_concept_set.py
+++ b/tests/test_concept_set.py
@@ -1,0 +1,135 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from athena_client.concept_set import ConceptSetGenerator
+from athena_client.models import Concept, ConceptType
+
+
+class TestConceptSetGenerator:
+    @pytest.mark.asyncio
+    async def test_tier1_happy_path(self):
+        explorer = Mock()
+        concept = Concept(
+            id=1,
+            name="A",
+            domain="Condition",
+            vocabulary="SNOMED",
+            className="Clinical",
+            standardConcept=ConceptType.STANDARD,
+            code="A",
+        )
+        explorer.map_to_standard_concepts = AsyncMock(
+            return_value=[{"concept": concept}]
+        )
+
+        db = Mock()
+        db.validate_concepts.return_value = [1]
+        db.get_descendants.return_value = [2, 3]
+
+        generator = ConceptSetGenerator(explorer, db)
+        result = await generator.create_from_query("test")
+
+        assert set(result["concept_ids"]) == {1, 2, 3}
+        assert result["metadata"]["status"] == "SUCCESS"
+        assert "Tier 1" in result["metadata"]["strategy_used"]
+
+    @pytest.mark.asyncio
+    async def test_tier1_no_descendants(self):
+        explorer = Mock()
+        concept = Concept(
+            id=1,
+            name="A",
+            domain="Condition",
+            vocabulary="SNOMED",
+            className="Clinical",
+            standardConcept=ConceptType.STANDARD,
+            code="A",
+        )
+        explorer.map_to_standard_concepts = AsyncMock(
+            return_value=[{"concept": concept}]
+        )
+
+        db = Mock()
+        db.validate_concepts.return_value = [1]
+        db.get_descendants.return_value = []
+
+        generator = ConceptSetGenerator(explorer, db)
+        result = await generator.create_from_query("test")
+
+        assert result["concept_ids"] == [1]
+        assert result["metadata"]["status"] == "SUCCESS"
+
+    @pytest.mark.asyncio
+    async def test_tier1_api_concept_not_in_local_db(self):
+        explorer = Mock()
+        concept = Concept(
+            id=1,
+            name="A",
+            domain="Condition",
+            vocabulary="SNOMED",
+            className="Clinical",
+            standardConcept=ConceptType.STANDARD,
+            code="A",
+        )
+        explorer.map_to_standard_concepts = AsyncMock(
+            return_value=[{"concept": concept}]
+        )
+
+        db = Mock()
+        db.validate_concepts.return_value = []
+
+        generator = ConceptSetGenerator(explorer, db)
+        result = await generator.create_from_query("test")
+
+        assert result["metadata"]["status"] == "FAILURE"
+
+    @pytest.mark.asyncio
+    async def test_strict_strategy_failure(self):
+        explorer = Mock()
+        concept = Concept(
+            id=1,
+            name="A",
+            domain="Condition",
+            vocabulary="SNOMED",
+            className="Clinical",
+            standardConcept=ConceptType.STANDARD,
+            code="A",
+        )
+        explorer.map_to_standard_concepts = AsyncMock(
+            return_value=[{"concept": concept}]
+        )
+
+        db = Mock()
+        db.validate_concepts.return_value = []
+
+        generator = ConceptSetGenerator(explorer, db)
+        result = await generator.create_from_query("test", strategy="strict")
+
+        assert result["metadata"]["status"] == "FAILURE"
+
+    @pytest.mark.asyncio
+    async def test_include_descendants_false(self):
+        explorer = Mock()
+        concept = Concept(
+            id=1,
+            name="A",
+            domain="Condition",
+            vocabulary="SNOMED",
+            className="Clinical",
+            standardConcept=ConceptType.STANDARD,
+            code="A",
+        )
+        explorer.map_to_standard_concepts = AsyncMock(
+            return_value=[{"concept": concept}]
+        )
+
+        db = Mock()
+        db.validate_concepts.return_value = [1]
+        db.get_descendants.return_value = [2]
+
+        generator = ConceptSetGenerator(explorer, db)
+        result = await generator.create_from_query("test", include_descendants=False)
+
+        assert result["concept_ids"] == [1]
+        assert result["metadata"]["status"] == "SUCCESS"


### PR DESCRIPTION
## Summary
- add `ConceptSetGenerator` class for tiered concept set generation
- expose a new `generate_concept_set` method in `AthenaAsyncClient`
- extend database connectors with `get_descendants`
- implement descendant lookup in `SQLAlchemyConnector`
- test concept set generation and descendant querying
- test runtime error when database connector is missing

## Testing
- `ruff check athena_client tests`
- `mypy athena_client`
- `bandit -c pyproject.toml -r athena_client -s B101,B404,B603`
- `pytest -q`
- `make quality`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68544d9666b4832c990e06d483278aa0