### PR TITLE
Add concept set generation API & CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,9 +651,40 @@ athena = Athena(timeout=60)  # Increase timeout for complex operations
 ✅ **Progress tracking** with ETA for long operations  
 ✅ **User-friendly warnings** for potentially large queries  
 ✅ **Smart pagination** with automatic validation  
-✅ **Enhanced error messages** with specific suggestions  
-✅ **Memory-efficient processing** for large result sets  
-✅ **Configurable thresholds** for different query types  
+✅ **Enhanced error messages** with specific suggestions
+✅ **Memory-efficient processing** for large result sets
+✅ **Configurable thresholds** for different query types
+
+## Generating Validated Concept Sets
+
+Concept set generation bridges the gap between the Athena API and your local OMOP vocabulary.
+It validates concepts found via the API against your database, optionally expanding the set with
+descendants. The returned metadata explains which strategy was used and lists any warnings.
+
+```python
+import asyncio
+from athena_client import Athena
+
+async def main() -> None:
+    client = Athena()
+    concept_set = await client.generate_concept_set(
+        "type 2 diabetes",
+        db_connection_string="postgresql://user:pass@localhost/omop",
+    )
+    print(concept_set)
+
+asyncio.run(main())
+```
+
+Command line usage:
+
+```bash
+athena generate-set "type 2 diabetes" \
+  --db-connection postgresql://user:pass@localhost/omop --output json
+```
+
+The `metadata` field indicates the strategy applied (e.g., `Tier 1: Direct Standard Concept`) and
+any warnings encountered.
 
 ## CLI Usage
 

--- a/examples/concept_set_demo.py
+++ b/examples/concept_set_demo.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Example demonstrating concept set generation."""
+
+import asyncio
+
+from athena_client import Athena
+
+
+async def main() -> None:
+    client = Athena()
+    result = await client.generate_concept_set(
+        "hypertension",
+        db_connection_string="postgresql://user:pass@localhost/omop",
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `generate_concept_set` to `AthenaClient`
- implement `generate-set` command in CLI
- document concept set generation
- provide example script
- test facade method and CLI command

## Testing
- `mypy athena_client/client.py athena_client/cli.py examples/concept_set_demo.py`
- `ruff check tests/test_client.py tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545e5f3dc8832c81b554d09e01793f